### PR TITLE
V8-patch2.diff fix for V8 r12718

### DIFF
--- a/patches/V8-patch2.diff
+++ b/patches/V8-patch2.diff
@@ -5,9 +5,8 @@
    // construct a hashable id, so if more than 2^17 are allowed, this
    // should be checked.
 -  static const int kMaxNumFunctionParameters = 32766;
--  static const int kMaxNumFunctionLocals = 32767;
 +  static const int kMaxNumFunctionParameters = 65534; //32766;
-+  static const int kMaxNumFunctionLocals = 65533; //32767;
+   static const int kMaxNumFunctionLocals = 131071;  // 2^17-1
  
    enum Mode {
      PARSE_LAZILY,


### PR DESCRIPTION
This is to fix Step 2 in the instructions...

```
2. Patch V8 source code with the patches you can find in thug/patches
   directory

    $ cp thug/patches/V8-patch* .
    $ patch -p0 < V8-patch1.diff 
    patching file v8/src/log.h
    $ patch -p0 < V8-patch2.diff 
    patching file v8/src/parser.h
    Hunk #1 succeeded at 456 (offset 7 lines).
```

However:

```
innismir@fullerton:~/thug_test$ patch -p0 < V8-patch2.diff 
patching file v8/src/parser.h
Hunk #1 FAILED at 449.
1 out of 1 hunk FAILED -- saving rejects to file v8/src/parser.h.rej
innismir@fullerton:~/thug_test$ 
```

v8/src/parser.h has changed slightly in r12718, with kMaxNumFunctionLocals now set at 131071. I've eliminated that from the patch since it's more than 65533. kMaxNumFunctionParameters remains in the patch, increasing it from 32766 to 65534.
