### PR TITLE
little bugfix for websites with unicode data

### DIFF
--- a/src/Logging/JSONLog.py
+++ b/src/Logging/JSONLog.py
@@ -63,7 +63,7 @@ class JSONLog(object):
 
         @data  data to encode properly
         """
-        return str(data).replace("\n", "").strip()
+        return unicode(data).replace("\n", "").strip()
 
     def make_counter(self, p):
         id = p


### PR DESCRIPTION
Bug details:

  File "thug/src/Logging/JSONLog.py", line 66, in fix
    return str(data).replace("\n", "").strip()
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2122' in
position 50: ordinal not in range(128)
