### PR TITLE
changed Window._context

### DIFF
--- a/src/DOM/Window.py
+++ b/src/DOM/Window.py
@@ -119,6 +119,7 @@ class Window(PyV8.JSClass):
         self._opener = opener
         self._screen = screen or Screen(width, height, 32)
         self._closed = False
+        self._context = None
         
         self._personality = personality
         self.__init_personality()
@@ -849,7 +850,7 @@ class Window(PyV8.JSClass):
 
     @property
     def context(self):
-        if not hasattr(self, '_context'):
+        if self._context is None:
             self._context = PyV8.JSContext(self)
             with self._context as ctxt:
                 thug_js = os.path.join(os.path.dirname(os.path.abspath(__file__)), "thug.js")


### PR DESCRIPTION
when `if not hasattr(self, '_context')` is used the context property is't working as expected. it is called again and again, makes the startup very slow. with this fix the whole app runs from >10 secs in <1sec.
