### PR TITLE
Added support for RabbitMQ servers that are protected by passwords.

### DIFF
--- a/src/config.ini
+++ b/src/config.ini
@@ -10,3 +10,7 @@ queue = thugres
 
 ; Result directory
 resdir = ../logs/results
+
+[credentials]
+username=guest
+password=guest

--- a/src/thugctrl.py
+++ b/src/thugctrl.py
@@ -24,6 +24,8 @@ class ThugCtrl():
 
         self.host = "localhost"
         self.queue = "thugctrl"
+        self.username = "guest"
+        self.password = "guest"
         self.extensive = extensive
         self.threshold = threshold
         self.referer = referer
@@ -40,10 +42,13 @@ class ThugCtrl():
         conf.read(self.configfile)
         self.host = conf.get("jobs", "host")
         self.queue = conf.get("jobs", "queue")
+        self.username = conf.get("credentials", "username")
+        self.password = conf.get("credentials", "password")
 
     def send_command(self, data):
+        credentials = pika.PlainCredentials(self.username, self.password)
         connection = pika.BlockingConnection(pika.ConnectionParameters(
-        host=self.host))
+            host=self.host, credentials = credentials))
         channel = connection.channel()
 
         channel.queue_declare(queue=self.queue, durable=True)
@@ -99,10 +104,13 @@ class ThugCollect():
         self.queue = "thugctrl"
         self.rhost = "localhost"
         self.rqueue = "thugres"
+        self.username = "guest"
+        self.password = "guest"
         self.read_config()
 
+        credentials = pika.PlainCredentials(self.username, self.password)
         connection = pika.BlockingConnection(pika.ConnectionParameters(
-            host=self.rhost))
+            host=self.rhost, credentials = credentials))
         channel = connection.channel()
 
         channel.queue_declare(queue=self.rqueue, durable=True)
@@ -126,6 +134,9 @@ class ThugCollect():
 
         self.rhost = conf.get("results", "host")
         self.rqueue = conf.get("results", "queue")
+
+        self.username = conf.get("credentials", "username")
+        self.password = conf.get("credentials", "password")
 
 
 if __name__ == "__main__":

--- a/src/thugd.py
+++ b/src/thugd.py
@@ -32,6 +32,8 @@ class Thugd():
         @clear:         Clear the job chain
         """
         self.clear = clear
+        self.username = "guest"
+        self.password = "guest"
         self._read_config(configfile)
         self._run_queue()
 
@@ -58,9 +60,12 @@ class Thugd():
         self.rhost  = conf.get("results", "host")
         self.rqueue = conf.get("results", "queue")
         self.resdir = conf.get("results", "resdir")
+        self.username   = conf.get("credentials", "username")
+        self.password  = conf.get("credentials", "password")
 
     def _run_queue(self):
-        parameters = pika.ConnectionParameters(host = self.host)
+        credentials = pika.PlainCredentials(self.username, self.password)
+        parameters = pika.ConnectionParameters(host = self.host, credentials = credentials)
         connection = pika.BlockingConnection(parameters)
         channel    = connection.channel()
 
@@ -82,7 +87,8 @@ class Thugd():
                 break
 
     def send_results(self, data):
-        parameters = pika.ConnectionParameters(host = self.rhost)
+        credentials = pika.PlainCredentials(self.username, self.password)
+        parameters = pika.ConnectionParameters(host = self.rhost, credentials = credentials)
         connection = pika.BlockingConnection(parameters)
         channel    = connection.channel()
 


### PR DESCRIPTION
Since I am using thug with password-protected rabbitmq servers, I added this code. The config.ini contains the standard RabbitMQ credentials guest/guest so that migration shouldn't be any problem.
