### PR TITLE
Fix infinite recursion problem in Window.__getattr__

### DIFF
--- a/src/DOM/Window.py
+++ b/src/DOM/Window.py
@@ -134,6 +134,7 @@ class Window(PyV8.JSClass):
         self.outerHeight   = height
         self.timers        = []
         self.java          = java()
+        self.inV8          = False
 
     def __getattr__(self, name):
         if name == 'constructor':
@@ -150,9 +151,18 @@ class Window(PyV8.JSClass):
         if name in ('__members__', '__methods__'):
             raise AttributeError(name)
 
+        if name in ('_context'):
+            return self.__getattribute__(name)
+
+        if self.inV8:
+            raise AttributeError(name)
+
         try:
+            self.inV8 = True
             symbol = self.context.eval(name)
+            self.inV8 = False
         except:
+            self.inV8 = False
             raise AttributeError(name)
 
         if isinstance(symbol, PyV8.JSFunction):


### PR DESCRIPTION
Window object has infinite recursion when the following two conditions:

1) Check whether the V8 JSContext has been initialized through **getattr**(). It would be a lookup loop which always calls **getattr**() since the code uses self.context before initializing V8 JSContext.

Fix by: Raise attribute error if **getattribute**() can't find "_context" variable.

2) Get the nonexistent variable or function by "self.context.eval(name)". When V8 JSContext can't find the variable, it will call **getattr**() again. It also becomes a lookup loop.

Fix by: Avoid to call **getattr**() from V8Context internal.
# > python -m cProfile thug.py -l ../samples/Events/testEvent10.html

Before fix:
  ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    588/5    0.193    0.000    0.759    0.152 Window.py:138(**getattr**)
     6825    0.003    0.000    0.003    0.000 Window.py:196(window)
  616/344    0.378    0.001    0.599    0.002 Window.py:850(context)

After fix:
  ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    55/37    0.014    0.000    0.014    0.000 Window.py:139(**getattr**)
       35    0.000    0.000    0.000    0.000 Window.py:206(window)
     82/4    0.004    0.000    0.020    0.005 Window.py:860(context)
