### PR TITLE
Use remote DNS when proxy scheme is HTTP

### DIFF
--- a/src/ThugAPI/ThugOpts.py
+++ b/src/ThugAPI/ThugOpts.py
@@ -78,7 +78,8 @@ class ThugOpts(dict):
                                               proxy_host = p.hostname,
                                               proxy_port = p.port if p.port else 8080,
                                               proxy_user = p.username,
-                                              proxy_pass = p.password)
+                                              proxy_pass = p.password,
+                                              proxy_rdns = (proxy_scheme == "HTTP"))
 
     def get_proxy_info(self):
         return self._proxy_info


### PR DESCRIPTION
If proxy_rdns is not True when proxy is http the client will try to resolve the remote host instead of delegate in proxy DNS.
http://bitworking.org/projects/httplib2/ref/module-httplib2.html
