### PR TITLE
_normalize_url no longer exists since HTTP Session support

### DIFF
--- a/src/DOM/DFT.py
+++ b/src/DOM/DFT.py
@@ -983,7 +983,7 @@ class DFT(object):
             if handler and handler(src, response.content):
                 return
 
-        _src = self.window._navigator._normalize_url(src)
+        _src = log.HTTPSession.normalize_url(self.window, src)
         if _src:
             src = _src
 


### PR DESCRIPTION
Change the call to _normalize_url to match the updated one in Navigator.py

fixes #111 