### PR TITLE
Change needed for mongodb start

### DIFF
--- a/doc/source/docker.rst
+++ b/doc/source/docker.rst
@@ -49,7 +49,7 @@ Then mount your host ~/logs dir and enable it to keep the logs on the host
 
 .. code-block:: sh
 
-    $ docker run -it -v ~/logs:/logs honeynet/thug /bin/bash
+    $ docker run -it -v ~/logs:/logs honeynet/thug
 
 Test the dockerized Thug inside the container analyzing 20 random samples
 


### PR DESCRIPTION
With this change a startup script is called to start the mongodb server before dropping to the shell.