### PR TITLE
Add runtime VirusTotal API key in ThugAPI and ThugOpts

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1,7 +1,8 @@
 .. _api:
 
 Thug API
-========
+========
+
 
 Thug provides a Python Application Program Interface (API) which allows external tools
 easily interfacing with Thug. Basic usage of the Thug API is really simple and just
@@ -470,6 +471,26 @@ Thug API interface definition is reported below for convenience.
             Enable VirusTotal samples submit
 
             @return: None
+            """
+
+        def set_vt_runtime_apikey():
+            """
+            set_vt_runtime_apikey
+
+            Set the key to be used when interacting with VirusTotal APIs, overriding
+            any static value defined in virustotal.conf
+
+            @return: None
+            """
+
+         def get_vt_runtime_apikey():
+            """
+            get_vt_runtime_apikey
+
+            Get the VirusTotal API key set as runtime parameter (not the one defined in
+            the configuration file)
+
+            @return: string
             """
 
         def get_web_tracking():

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -125,15 +125,11 @@ VirusTotal is a free service that analyzes suspicious files and URLs and
 facilitates the quick detection of viruses, worms, trojans, and all kinds 
 of malware. 
 
-Thug supports VirusTotal but you need to get an API key to use the 
-VirusTotal Public API 2.0. To do so, just sign-up on the service at 
-https://www.virustotal.com/ and get your own API Key.
-
-To set up a static VirusTotal key that will be used every time you run Thug with the
---vtquery and --vtscan options, just rename the file src/virustotal/virustotal.conf.sample
-in src/virustotal/virustotal.conf and insert your own API key in the configuration file
-as shown below. Please note that you can avoid redefining both scanurl and reporturl if
-you are happy with the default values, which can be found in src/virustotal/virustotal.default.conf
+Thug supports VirusTotal and a default API key is now included in the default
+configuration file (many thanks to the VirusTotal crew for this!). Please
+consider getting your own API key by signing-up on the service at 
+https://www.virustotal.com/. To change the default VirusTotal key with your
+own, simply edit *src/Analysis/virustotal/virustotal.conf* as follows:
 
 .. code-block:: sh
 

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -129,8 +129,11 @@ Thug supports VirusTotal but you need to get an API key to use the
 VirusTotal Public API 2.0. To do so, just sign-up on the service at 
 https://www.virustotal.com/ and get your own API Key.
 
-Rename the file src/virustotal/virustotal.conf.sample in src/virustotal/virustotal.conf
-and insert your own API key in the configuration file as shown below
+To set up a static VirusTotal key that will be used every time you run Thug with the
+--vtquery and --vtscan options, just rename the file src/virustotal/virustotal.conf.sample
+in src/virustotal/virustotal.conf and insert your own API key in the configuration file
+as shown below. Please note that you can avoid redefining both scanurl and reporturl if
+you are happy with the default values, which can be found in src/virustotal/virustotal.default.conf
 
 .. code-block:: sh
 
@@ -138,3 +141,7 @@ and insert your own API key in the configuration file as shown below
     apikey:                         <enter your API key here>
     scanurl:                        https://www.virustotal.com/vtapi/v2/file/scan
     reporturl:                      https://www.virustotal.com/vtapi/v2/file/report
+
+You may also pass a runtime value for the API key parameter by using the --vt-apikey or -b parameter:
+this may come handy when using a dockerized Thug instance where editing the configuration file prior
+to each run may not be so simple.

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -46,6 +46,7 @@ Let's start our Thug tour by taking a look at the options it provides.
         -B, --broken-url        Set the broken URL mode
         -y, --vtquery           Query VirusTotal for samples analysis
         -s, --vtsubmit          Submit samples to VirusTotal
+        -b, --vt-apikey=        VirusTotal API key to be used at runtime
         -z, --web-tracking      Enable web client tracking inspection
         -N, --no-honeyagent     Disable HoneyAgent support
 

--- a/src/Analysis/virustotal/VirusTotal.py
+++ b/src/Analysis/virustotal/VirusTotal.py
@@ -50,19 +50,13 @@ class VirusTotal(object):
     def __init_config(self):
         config = ConfigParser.ConfigParser()
 
-        # virustotal.default.conf should contain at least scanurl and reporturl
-        default_conf_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'virustotal.default.conf')
-        if not os.path.isfile(default_conf_file):
+        conf_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'virustotal.conf')
+
+        if not os.path.isfile(conf_file):
             self.enabled = False
             return
 
-        with open(default_conf_file, 'rb') as default_conf:
-            config.read_file(default_conf)
-
-        conf_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'virustotal.conf')
-
-        if os.path.isfile(conf_file):
-            config.read(conf_file)
+        config.read(conf_file)
 
         for option in config.options('VirusTotal'):
             self.opts[option] = config.get('VirusTotal', option)

--- a/src/Analysis/virustotal/VirusTotal.py
+++ b/src/Analysis/virustotal/VirusTotal.py
@@ -50,15 +50,29 @@ class VirusTotal(object):
     def __init_config(self):
         config = ConfigParser.ConfigParser()
 
-        conf_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'virustotal.conf')
-        if not os.path.isfile(conf_file):
+        # virustotal.default.conf should contain at least scanurl and reporturl
+        default_conf_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'virustotal.default.conf')
+        if not os.path.isfile(default_conf_file):
             self.enabled = False
             return
 
-        config.read(conf_file)
+        with open(default_conf_file, 'rb') as default_conf:
+            config.read_file(default_conf)
+
+        conf_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'virustotal.conf')
+
+        if os.path.isfile(conf_file):
+            config.read(conf_file)
 
         for option in config.options('VirusTotal'):
             self.opts[option] = config.get('VirusTotal', option)
+
+        runtime_apikey = log.ThugOpts.get_vt_runtime_apikey()
+        if runtime_apikey:
+            self.opts['apikey'] = runtime_apikey
+
+        if not self.opts.get('apikey', None):
+            self.enabled = False
 
     def save_report(self, response_dict, basedir, sample):
         log_dir = os.path.join(basedir, 'analysis', 'virustotal')

--- a/src/Logging/virustotal.default.conf
+++ b/src/Logging/virustotal.default.conf
@@ -1,0 +1,5 @@
+# DO NOT DELETE NOR EDIT THIS FILE
+# If you need to override any value, please create your own virustotal.conf file
+[VirusTotal]
+scanurl:			https://www.virustotal.com/vtapi/v2/file/scan
+reporturl:			https://www.virustotal.com/vtapi/v2/file/report

--- a/src/ThugAPI/ThugAPI.py
+++ b/src/ThugAPI/ThugAPI.py
@@ -217,6 +217,12 @@ class ThugAPI:
     def set_vt_submit(self):
         log.ThugOpts.set_vt_submit()
 
+    def set_vt_runtime_apikey(self, vt_apikey):
+        log.ThugOpts.vt_runtime_apikey = vt_runtime_apikey
+
+    def get_vt_runtime_apikey(self):
+        return log.ThugOpts.vt_runtime_apikey
+
     def add_urlclassifier(self, rule):
         log.URLClassifier.add_rule(rule)
 

--- a/src/ThugAPI/ThugAPI.py
+++ b/src/ThugAPI/ThugAPI.py
@@ -217,7 +217,7 @@ class ThugAPI:
     def set_vt_submit(self):
         log.ThugOpts.set_vt_submit()
 
-    def set_vt_runtime_apikey(self, vt_apikey):
+    def set_vt_runtime_apikey(self, vt_runtime_apikey):
         log.ThugOpts.vt_runtime_apikey = vt_runtime_apikey
 
     def get_vt_runtime_apikey(self):

--- a/src/ThugAPI/ThugOpts.py
+++ b/src/ThugAPI/ThugOpts.py
@@ -55,6 +55,7 @@ class ThugOpts(dict):
         self._broken_url      = False
         self._vt_query        = False
         self._vt_submit       = False
+        self._vt_runtime_apikey = None
         self._web_tracking    = False
         self._honeyagent      = True
         self._cache           = '/tmp/thug-cache-%s' % (os.getuid(), )
@@ -212,6 +213,14 @@ class ThugOpts(dict):
         self._vt_submit = True
 
     vt_submit = property(get_vt_submit, set_vt_submit)
+
+    def get_vt_runtime_apikey(self):
+        return self._vt_runtime_apikey
+
+    def set_vt_runtime_apikey(self, vt_apikey):
+        self._vt_runtime_apikey = vt_apikey
+
+    vt_runtime_apikey = property(get_vt_runtime_apikey, set_vt_runtime_apikey)
 
     def get_web_tracking(self):
         return self._web_tracking

--- a/src/thug.py
+++ b/src/thug.py
@@ -64,6 +64,7 @@ Synopsis:
         -B, --broken-url    \tSet the broken URL mode
         -y, --vtquery       \tQuery VirusTotal for samples analysis
         -s, --vtsubmit      \tSubmit samples to VirusTotal
+        -b, --vt-apikey     \tVirusTotal API key to be used at runtime
         -z, --web-tracking  \tEnable web client tracking inspection
         -N, --no-honeyagent \tDisable HoneyAgent support
 
@@ -101,7 +102,7 @@ Synopsis:
 
         try:
             options, args = getopt.getopt(self.args,
-                                          'hVu:e:w:n:o:r:p:yszNlxvdqmagA:PS:RJ:Kt:ET:BQ:W:C:FZM',
+                                          'hVu:e:w:n:o:r:p:yszNlxvdqmagA:PS:RJ:Kt:ET:BQ:W:C:FZMb:',
                 ['help',
                 'version',
                 'useragent=',
@@ -139,6 +140,7 @@ Synopsis:
                 'file-logging',
                 'json-logging',
                 'maec11-logging',
+                'vt-apikey=',
                 ])
         except getopt.GetoptError:
             self.usage()
@@ -167,6 +169,8 @@ Synopsis:
                 self.set_vt_query()
             elif option[0] in ('-s', '--vtsubmit', ):
                 self.set_vt_submit()
+            elif option[0] in ('-b', '--vt-apikey', ):
+                self.set_vt_runtime_apikey(option[1])
             elif option[0] in ('-z', '--web-tracking', ):
                 self.set_web_tracking()
             elif option[0] in ('-N', '--no-honeyagent', ):

--- a/src/thug.py
+++ b/src/thug.py
@@ -64,7 +64,7 @@ Synopsis:
         -B, --broken-url    \tSet the broken URL mode
         -y, --vtquery       \tQuery VirusTotal for samples analysis
         -s, --vtsubmit      \tSubmit samples to VirusTotal
-        -b, --vt-apikey     \tVirusTotal API key to be used at runtime
+        -b, --vt-apikey=    \tVirusTotal API key to be used at runtime
         -z, --web-tracking  \tEnable web client tracking inspection
         -N, --no-honeyagent \tDisable HoneyAgent support
 


### PR DESCRIPTION
Allow users to specify a runtime key for VirusTotal APIs.

This may come handy when using a dockerized Thug version where editing the `virustotal.conf` file prior to each run is difficult.

I also created a `virustotal.default.conf` file that should always be there and that contains the default values for the `scanurl` and `reporturl` options; now, `virustotal.conf` can be used to store non-default values for those variables along with the primary API key. Also, `virustotal.conf` is not mandatory any more, since you could live with `virustotal.default.conf` plus a runtime API key value (e.g. the `--vt-apikey` command line option).