### PR TITLE
Adding runtime configuration for MongoDB database address

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -473,23 +473,6 @@ Thug API interface definition is reported below for convenience.
             @return: None
             """
 
-        def get_mongodb_instance():
-            """
-            get_mongodb_instance
-
-            Get the address ("host:port") of the MongoDB instance specified at runtime
-            (not the one from the logging.conf file)
-            """
-
-        def set_mongodb_instance():
-            """
-            set_mongodb_instance
-
-            Set the address ("host:port") of a running MongoDB instance to be used at runtime
-
-            @return: None
-            """
-
          def get_vt_runtime_apikey():
             """
             get_vt_runtime_apikey
@@ -506,6 +489,23 @@ Thug API interface definition is reported below for convenience.
 
             Set the key to be used when interacting with VirusTotal APIs, overriding
             any static value defined in virustotal.conf
+
+            @return: None
+            """
+
+        def get_mongodb_instance():
+            """
+            get_mongodb_instance
+
+            Get the address ("host:port") of the MongoDB instance specified at runtime
+            (not the one from the logging.conf file)
+            """
+
+        def set_mongodb_instance():
+            """
+            set_mongodb_instance
+
+            Set the address ("host:port") of a running MongoDB instance to be used at runtime
 
             @return: None
             """

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1,7 +1,8 @@
 .. _api:
 
 Thug API
-========
+========
+
 
 Thug provides a Python Application Program Interface (API) which allows external tools
 easily interfacing with Thug. Basic usage of the Thug API is really simple and just
@@ -468,6 +469,25 @@ Thug API interface definition is reported below for convenience.
             set_vt_submit
 
             Enable VirusTotal samples submit
+
+            @return: None
+            """
+
+        def get_mongodb_instance():
+            """
+            get_mongodb_instance
+
+            Get the address ("host:port") of the MongoDB instance specified at runtime
+            (not the one from the logging.conf file)
+
+            @return: None
+            """
+
+        def set_mongodb_instance():
+            """
+            set_mongodb_instance
+
+            Set the address ("host:port") of a running MongoDB instance to be used at runtime
 
             @return: None
             """

--- a/doc/source/logging.rst
+++ b/doc/source/logging.rst
@@ -67,6 +67,12 @@ The parameters should be quite intuitive to understand. By the way if you instal
 MongoDB on the same host you are supposed to run Thug you should not need changing
 anything in the default configuration.
 
+If you want Thug to store its results to a different MongoDB instance than that defined
+in your *Logging/logging.conf* file, you can specify a different address at runtime, for
+example by using the *--mongodb-address* option from the command line. This can be especially
+useful when using the dockerized version of Thug, where storing results in Docker itself would
+mean to loose them as soon as the Docker instance is shut down.
+
 
 Collection schema
 -----------------

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -48,6 +48,7 @@ Let's start our Thug tour by taking a look at the options it provides.
         -s, --vtsubmit          Submit samples to VirusTotal
         -z, --web-tracking      Enable web client tracking inspection
         -N, --no-honeyagent     Disable HoneyAgent support
+        -D, --mongodb-address   Specify address and port of the MongoDB instance ("host:port")
 
         Plugins:
         -A, --adobepdf=         Specify the Adobe Acrobat Reader version (default: 9.1.0)

--- a/src/Logging/modules/MongoDB.py
+++ b/src/Logging/modules/MongoDB.py
@@ -72,6 +72,13 @@ class MongoDB(object):
         for option in config.options('mongodb'):
             self.opts[option] = config.get('mongodb', option)
 
+        if log.ThugOpts.mongodb_address:
+            try:
+                (self.opts['host'], self.opts['port']) = log.ThugOpts.mongodb_address.split(':', 1)
+                self.opts['enable'] = 'True'
+            except:
+                log.warning("Invalid MongoDB address specified at runtime, using default values instead")
+
         if self.opts['enable'].lower() in ('false', ):
             self.enabled = False
 

--- a/src/ThugAPI/ThugAPI.py
+++ b/src/ThugAPI/ThugAPI.py
@@ -217,17 +217,17 @@ class ThugAPI:
     def set_vt_submit(self):
         log.ThugOpts.set_vt_submit()
 
-    def get_mongodb_address(self):
-        return log.ThugOpts.mongodb_address
-
-    def set_mongodb_address(self, mongodb_address):
-        log.ThugOpts.mongodb_address = mongodb_address
-
     def get_vt_runtime_apikey(self):
         return log.ThugOpts.vt_runtime_apikey
 
     def set_vt_runtime_apikey(self, vt_runtime_apikey):
         log.ThugOpts.vt_runtime_apikey = vt_runtime_apikey
+
+    def get_mongodb_address(self):
+        return log.ThugOpts.mongodb_address
+
+    def set_mongodb_address(self, mongodb_address):
+        log.ThugOpts.mongodb_address = mongodb_address
 
     def add_urlclassifier(self, rule):
         log.URLClassifier.add_rule(rule)

--- a/src/ThugAPI/ThugAPI.py
+++ b/src/ThugAPI/ThugAPI.py
@@ -217,6 +217,12 @@ class ThugAPI:
     def set_vt_submit(self):
         log.ThugOpts.set_vt_submit()
 
+    def get_mongodb_address(self):
+        return log.ThugOpts.mongodb_address
+
+    def set_mongodb_address(self, mongodb_address):
+        log.ThugOpts.mongodb_address = mongodb_address
+
     def add_urlclassifier(self, rule):
         log.URLClassifier.add_rule(rule)
 

--- a/src/ThugAPI/ThugOpts.py
+++ b/src/ThugAPI/ThugOpts.py
@@ -56,6 +56,7 @@ class ThugOpts(dict):
         self._vt_query        = False
         self._vt_submit       = False
         self._vt_runtime_apikey = None
+	self._mongodb_address = None
         self._web_tracking    = False
         self._honeyagent      = True
         self._cache           = '/tmp/thug-cache-%s' % (os.getuid(), )

--- a/src/ThugAPI/ThugOpts.py
+++ b/src/ThugAPI/ThugOpts.py
@@ -228,3 +228,11 @@ class ThugOpts(dict):
         self._honeyagent = enabled
 
     honeyagent = property(get_honeyagent, set_honeyagent)
+
+    def get_mongodb_address(self):
+        return self._mongodb_address
+
+    def set_mongodb_address(self, mongodb_address):
+        self._mongodb_address = mongodb_address
+
+    mongodb_address = property(get_mongodb_address, set_mongodb_address)

--- a/src/ThugAPI/ThugOpts.py
+++ b/src/ThugAPI/ThugOpts.py
@@ -56,7 +56,7 @@ class ThugOpts(dict):
         self._vt_query        = False
         self._vt_submit       = False
         self._vt_runtime_apikey = None
-	self._mongodb_address = None
+        self._mongodb_address = None
         self._web_tracking    = False
         self._honeyagent      = True
         self._cache           = '/tmp/thug-cache-%s' % (os.getuid(), )

--- a/src/thug.py
+++ b/src/thug.py
@@ -84,6 +84,7 @@ Synopsis:
         -F, --file-logging  \tEnable file logging mode (default: disabled)
         -Z, --json-logging  \tEnable JSON logging mode (default: disabled)
         -M, --maec11-logging\tEnable MAEC11 logging mode (default: disabled)
+        -D, --mongodb-address\tSpecify address and port of the MongoDB instance ("host:port")
 
     Proxy Format:
         scheme://[username:password@]host:port (supported schemes: http, socks4, socks5)
@@ -101,7 +102,7 @@ Synopsis:
 
         try:
             options, args = getopt.getopt(self.args,
-                                          'hVu:e:w:n:o:r:p:yszNlxvdqmagA:PS:RJ:Kt:ET:BQ:W:C:FZM',
+                                          'hVu:e:w:n:o:r:p:yszNlxvdqmagA:PS:RJ:Kt:ET:BQ:W:C:FZMD:',
                 ['help',
                 'version',
                 'useragent=',
@@ -139,6 +140,7 @@ Synopsis:
                 'file-logging',
                 'json-logging',
                 'maec11-logging',
+                'mongodb-address=',
                 ])
         except getopt.GetoptError:
             self.usage()
@@ -221,6 +223,8 @@ Synopsis:
                 self.set_json_logging()
             elif option[0] in ('-M', '--maec11-logging', ):
                 self.set_maec11_logging()
+            elif option[0] in ('-D', '--mongodb-address', ):
+                self.set_mongodb_address(option[1])
 
         self.log_init(args[0])
 


### PR DESCRIPTION
Let the user specify the address for the MongoDB database instance at runtime, in "host:port" format. This will override any value from `Logging/logging.conf`, including enabling the module if it was disabled in the configuration file.

This may be handy when using Docker, since using the MongoDB instance inside Docker would result in a loss of all results once the container is shut down.

Merged with the latest upstream changes from buffer/thug@a69c6ea3449fd00c7a4a69c9c80808e149125b2b.