### PR TITLE
Fixing docs with correct command to install python-magic

### DIFF
--- a/doc/source/build.rst
+++ b/doc/source/build.rst
@@ -372,16 +372,23 @@ to install pydot is through easy_install.
 Python-Magic
 ^^^^^^^^^^^^
 
-Python-Magic homepage is located at https://github.com/ahupp/python-magic.
+The recommended implementation of python-magic (currently 0.4.6) can be
+found at https://github.com/ahupp/python-magic.
 
-If not available as a package for your Linux distribution, the best way
-to install python-magic is through easy_install.
+The best way to install python-magic is through easy_install.
 
 .. code-block:: sh
 
-        # easy_install magic
+        # easy_install python-magic
 
- 
+If you are running Ubuntu, you may want to use a completely different
+implementation of python-magic (5.x) which is packaged through apt.
+
+.. code-block:: sh
+
+        # apt-get install python-magic
+
+
 Rarfile
 ^^^^^^^
 


### PR DESCRIPTION
Unfortunately there are three different implementations of `magic` for python:
* python-magic 0.4.6 from pypi
* python-magic 5.x from apt
* filemagic 1.6 from pypi

Thug can use either one of the first two, but the docs were reporting a wrong install command.