### PR TITLE
Allow usage of filemagic instead of python-magic

### DIFF
--- a/src/DOM/Navigator.py
+++ b/src/DOM/Navigator.py
@@ -44,7 +44,7 @@ class Navigator(PyV8.JSClass):
         self._plugins    = Plugins()  # An array of the plugins installed in the browser
         self._mimeTypes  = MimeTypes()
         self._window     = window
-   
+
         for p in self._mimeTypes.values():
             self._plugins.append(p['enabledPlugin'])
 
@@ -229,7 +229,7 @@ class Navigator(PyV8.JSClass):
         """
         return self.personality['vendor']
 
-    @property 
+    @property
     def _vendorSub(self):
         """
             The vendor name of the current browser (e.g. "Netscape6")
@@ -343,13 +343,21 @@ class Navigator(PyV8.JSClass):
         sha256.update(response.content)
 
         try:
+            # This works with python-magic >= 0.4.6 from pypi
             mtype = magic.from_buffer(response.content)
         except:
-            # Ubuntu workaround
-            # There is an old pymagic version in Ubuntu
-            ms = magic.open(magic.MAGIC_NONE)
-            ms.load()
-            mtype = ms.buffer(response.content)
+            try:
+                # Ubuntu workaround
+                # This works with python-magic >= 5.22 from Ubuntu (apt)
+                ms = magic.open(magic.MAGIC_NONE)
+                ms.load()
+                mtype = ms.buffer(response.content)
+            except:
+                # Filemagic workaround
+                # This works with filemagic >= 1.6 from pypi
+                with magic.Magic() as m:
+                    mtype = m.id_buffer(response.content)
+
 
         data = {
             "content" : response.content,


### PR DESCRIPTION
This small fix allows people to use filemagic >= 1.6 from pypi instead than one of the two python-magic versions.