### PR TITLE
Always return real mime type

### DIFF
--- a/src/DOM/Navigator.py
+++ b/src/DOM/Navigator.py
@@ -44,7 +44,7 @@ class Navigator(PyV8.JSClass):
         self._plugins    = Plugins()  # An array of the plugins installed in the browser
         self._mimeTypes  = MimeTypes()
         self._window     = window
-   
+
         for p in self._mimeTypes.values():
             self._plugins.append(p['enabledPlugin'])
 
@@ -229,7 +229,7 @@ class Navigator(PyV8.JSClass):
         """
         return self.personality['vendor']
 
-    @property 
+    @property
     def _vendorSub(self):
         """
             The vendor name of the current browser (e.g. "Netscape6")
@@ -343,13 +343,21 @@ class Navigator(PyV8.JSClass):
         sha256.update(response.content)
 
         try:
+            # This works with python-magic >= 0.4.6 from pypi
             mtype = magic.from_buffer(response.content)
         except:
-            # Ubuntu workaround
-            # There is an old pymagic version in Ubuntu
-            ms = magic.open(magic.MAGIC_NONE)
-            ms.load()
-            mtype = ms.buffer(response.content)
+            try:
+                # Ubuntu workaround
+                # This works with python-magic >= 5.22 from Ubuntu (apt)
+                ms = magic.open(magic.MAGIC_NONE)
+                ms.load()
+                mtype = ms.buffer(response.content)
+            except:
+                # Filemagic workaround
+                # This works with filemagic >= 1.6 from pypi
+                with magic.Magic() as m:
+                    mtype = m.id_buffer(response.content)
+
 
         data = {
             "content" : response.content,

--- a/src/DOM/Navigator.py
+++ b/src/DOM/Navigator.py
@@ -344,18 +344,18 @@ class Navigator(PyV8.JSClass):
 
         try:
             # This works with python-magic >= 0.4.6 from pypi
-            mtype = magic.from_buffer(response.content)
+            mtype = magic.from_buffer(response.content, mime=True)
         except:
             try:
                 # Ubuntu workaround
                 # This works with python-magic >= 5.22 from Ubuntu (apt)
-                ms = magic.open(magic.MAGIC_NONE)
+                ms = magic.open(magic.MAGIC_MIME)
                 ms.load()
-                mtype = ms.buffer(response.content)
+                mtype = ms.buffer(response.content).split(';')[0]
             except:
                 # Filemagic workaround
                 # This works with filemagic >= 1.6 from pypi
-                with magic.Magic() as m:
+                with magic.Magic(flags=magic.MAGIC_MIME_TYPE) as m:
                     mtype = m.id_buffer(response.content)
 
 


### PR DESCRIPTION
This fix should always return the real mime type instead of a textual description, that may vary according to the version of magic you're using, the operating system you're on, your locale, etc.

This should make it easier for tools to automatically understand when, for example, the real mime type sent by the server is different from the one it declares in the `content-type` HTTP hader.

This commit includes #132 but if you prefer I can make a new one starting from the current state of your master branch.