### PR TITLE
PyV8.JSLocker before DFT._run

### DIFF
--- a/src/DOM/DFT.py
+++ b/src/DOM/DFT.py
@@ -1225,6 +1225,7 @@ class DFT(object):
                 log.warning("[handle_element_event] Event %s not properly handled" % (evt, ))
 
     def run(self):
-        with self.context as ctx:
-            self._run()
-            self.check_shellcodes()
+        with PyV8.JSLocker():
+            with self.context as ctx:
+                self._run()
+                self.check_shellcodes()


### PR DESCRIPTION
Following segfault occured when django webapp called ThugAPI.run_local:

    [2015-09-27 10:35:54] Handling DOM Events: load,mousemove
    
    Program received signal SIGSEGV, Segmentation fault.
    0x00007ffff68e23b7 in kill () from /lib/x86_64-linux-gnu/libc.so.6
    (gdb) bt
    #0  0x00007ffff68e23b7 in kill () from /lib/x86_64-linux-gnu/libc.so.6
    #1  0x0000000000432870 in ?? ()
    #2  0x000000000054bb14 in PyEval_EvalFrameEx ()
    #3  0x0000000000575d92 in PyEval_EvalCodeEx ()
    #4  0x000000000054c028 in PyEval_EvalFrameEx ()
    #5  0x0000000000575d92 in PyEval_EvalCodeEx ()
    #6  0x000000000054c028 in PyEval_EvalFrameEx ()
    #7  0x0000000000575d92 in PyEval_EvalCodeEx ()
    #8  0x0000000000577be2 in ?? ()
    #9  0x00000000004d91b6 in PyObject_Call ()
    #10 0x000000000054d8a5 in PyEval_EvalFrameEx ()
    #11 0x0000000000575d92 in PyEval_EvalCodeEx ()
    #12 0x0000000000577be2 in ?? ()
    #13 0x00000000004d91b6 in PyObject_Call ()
    #14 0x000000000054d8a5 in PyEval_EvalFrameEx ()
    #15 0x0000000000575d92 in PyEval_EvalCodeEx ()
    #16 0x0000000000577be2 in ?? ()
    #17 0x00000000004d91b6 in PyObject_Call ()
    #18 0x000000000054d8a5 in PyEval_EvalFrameEx ()
    #19 0x0000000000575d92 in PyEval_EvalCodeEx ()
    #20 0x0000000000577be2 in ?? ()
    #21 0x00000000004d91b6 in PyObject_Call ()
    #22 0x000000000054d8a5 in PyEval_EvalFrameEx ()
    #23 0x0000000000575d92 in PyEval_EvalCodeEx ()
    #24 0x000000000054c028 in PyEval_EvalFrameEx ()
    #25 0x0000000000575d92 in PyEval_EvalCodeEx ()
    #26 0x000000000054c028 in PyEval_EvalFrameEx ()
    #27 0x0000000000575d92 in PyEval_EvalCodeEx ()
    #28 0x000000000054c028 in PyEval_EvalFrameEx ()
    #29 0x0000000000575d92 in PyEval_EvalCodeEx ()
    #30 0x00000000004c1352 in PyRun_SimpleFileExFlags ()
    #31 0x00000000004c754f in Py_Main ()
    #32 0x00007ffff68cd76d in __libc_start_main () from /lib/x86_64-linux-gnu/libc.so.6
    #33 0x000000000041ba41 in _start ()
    (gdb)

As a result of investigation,  I could locate segfault occured at
PyV8.JSContext in Window.context of DOM/Window.py.

Adding PyV8.JSLocker solved this problem.