### PR TITLE
MicrosoftXMLHTTP should ignore whitespaces after the domain

### DIFF
--- a/src/ActiveX/modules/MicrosoftXMLHTTP.py
+++ b/src/ActiveX/modules/MicrosoftXMLHTTP.py
@@ -3,6 +3,8 @@
 import os
 import hashlib
 import logging
+import urlparse
+import urllib
 
 try:
     import urllib.parse as urlparse
@@ -21,6 +23,11 @@ def abort(self):
 
 
 def open(self, bstrMethod, bstrUrl, varAsync = True, varUser = None, varPassword = None):
+    # Internet Explorer ignores any \r\n or %0d%0a or whitespace appended to the domain name
+    parsedUrl = urlparse.urlparse(bstrUrl)
+    netloc = urllib.unquote_plus(parsedUrl.netloc).strip()
+    bstrUrl = urlparse.urlunparse((parsedUrl.scheme, netloc, parsedUrl.path, parsedUrl.params, parsedUrl.query, parsedUrl.fragment))
+
     msg = "[Microsoft XMLHTTP ActiveX] open('%s', '%s', %s" % (bstrMethod, bstrUrl, varAsync is True, )
     if varUser:
         msg = "%s, '%s'" % (msg, varUser, )
@@ -38,7 +45,7 @@ def open(self, bstrMethod, bstrUrl, varAsync = True, varUser = None, varPassword
                                                 "async"  : str(varAsync)
                                              }
                                      )
-    
+
     self.bstrMethod  = bstrMethod
     self.bstrUrl     = str(bstrUrl)
     self.varAsync    = varAsync

--- a/src/ActiveX/modules/MicrosoftXMLHTTP.py
+++ b/src/ActiveX/modules/MicrosoftXMLHTTP.py
@@ -4,7 +4,6 @@ import os
 import hashlib
 import logging
 import urlparse
-import urllib
 
 try:
     import urllib.parse as urlparse
@@ -25,7 +24,7 @@ def abort(self):
 def open(self, bstrMethod, bstrUrl, varAsync = True, varUser = None, varPassword = None):
     # Internet Explorer ignores any \r\n or %0d%0a or whitespace appended to the domain name
     parsedUrl = urlparse.urlparse(bstrUrl)
-    netloc = urllib.unquote_plus(parsedUrl.netloc).strip()
+    netloc = parsedUrl.netloc.strip("\r\n\t")
     bstrUrl = urlparse.urlunparse((parsedUrl.scheme, netloc, parsedUrl.path, parsedUrl.params, parsedUrl.query, parsedUrl.fragment))
 
     msg = "[Microsoft XMLHTTP ActiveX] open('%s', '%s', %s" % (bstrMethod, bstrUrl, varAsync is True, )


### PR DESCRIPTION
While analyzing some malicious JavaScript files spammed as mail attachments, I discovered that the actual `MSXML2.XMLHTTP` ActiveX control does ignore any whitespaces inserted between the domain name and the URI path.

This patch should work around the problem by using urlparse and urllib to split the URL, decode any url-encoded part and strip whitespaces before reassembling the URL.