### PR TITLE
Implement msxml2.domdocument.3.0 and createElement() method

### DIFF
--- a/src/ActiveX/CLSID.py
+++ b/src/ActiveX/CLSID.py
@@ -50,7 +50,7 @@ CLSID = [
                             'SaveToFile'    : AdodbStream.SaveToFile,
                             'SaveTofile'    : AdodbStream.SaveToFile,
                             'Close'         : AdodbStream.Close,
-                          }
+                         }
         },
 
         # AnswerWorks
@@ -527,7 +527,7 @@ CLSID = [
         # MicrosoftXMLDOM
         {
             'id'        : (),
-            'name'      : ( 'microsoft.xmldom', ),
+            'name'      : ( 'microsoft.xmldom', 'msxml2.domdocument.3.0', ),
             'attrs'     : {
                             'async'            : False,
                             'parseError'       : XMLDOMParseError.XMLDOMParseError(),
@@ -535,6 +535,7 @@ CLSID = [
             'funcattrs' : {},
             'methods'   : {
                             'loadXML'          : MicrosoftXMLDOM.loadXML,
+                            'createElement'    : MicrosoftXMLDOM.createElement,
                           }
         },
 

--- a/src/ActiveX/modules/MicrosoftXMLDOM.py
+++ b/src/ActiveX/modules/MicrosoftXMLDOM.py
@@ -1,4 +1,5 @@
 # Microsoft XMLDOM
+from lxml import etree
 
 import bs4 as BeautifulSoup
 from DOM.W3C import w3c
@@ -26,3 +27,6 @@ def loadXML(self, bstrXML):
             log.ThugLogging.add_behavior_warn("[Microsoft XMLDOM ActiveX] Attempting to load %s" % (p, ))
             if any(sys.lower() in p.lower() for sys in security_sys):
                 self.parseError._errorCode = 0
+
+def createElement(self, bstrTagName):
+    return etree.Element(bstrTagName)


### PR DESCRIPTION
Found a nasty Nemucod variant that decodes a base64 string to a new document created via the `Msxml2.DOMDocument.3.0` ActiveX control. It then uses `ADODB.Stream` to drop the unpacked code to a local `.js` file, which is then executed via `WScript.Shell.run`.

Needed to add `msxml2.domdocument.3.0` and to implement the `createElement()` method to let Thug run it.