### PR TITLE
Implementing AdodbStream.SaveToFile

### DIFF
--- a/src/ActiveX/modules/AdodbStream.py
+++ b/src/ActiveX/modules/AdodbStream.py
@@ -1,12 +1,15 @@
-
+import StringIO
 import logging
+from Magic.Magic import Magic
 log = logging.getLogger("Thug")
 
 def open(self):
     log.ThugLogging.add_behavior_warn("[Adodb.Stream ActiveX] open")
+    self.fobject = StringIO.StringIO()
 
 def Write(self, s):
     log.ThugLogging.add_behavior_warn("[Adodb.Stream ActiveX] Write")
+    self.fobject.write(s)
 
 def SaveToFile(self, filename, opt):
     log.ThugLogging.add_behavior_warn("[Adodb.Stream ActiveX] SaveToFile (%s)" % (filename, ))
@@ -18,7 +21,15 @@ def SaveToFile(self, filename, opt):
                                              },
                                       forward = False)
 
+    content = self.fobject.getvalue()
+    mtype = Magic(content).get_mime()
+
+    log.ThugLogging.log_file(
+        content,
+        url=filename,
+        sampletype=mtype,
+    )
+
 def Close(self):
     log.ThugLogging.add_behavior_warn("[Adodb.Stream ActiveX] Close")
-
-
+    self.fobject.close()

--- a/src/DOM/Navigator.py
+++ b/src/DOM/Navigator.py
@@ -21,7 +21,6 @@ import os
 import hashlib
 import logging
 import socket
-import magic
 import ssl
 
 try:
@@ -34,6 +33,7 @@ from .MimeTypes import MimeTypes
 from .Plugins import Plugins
 from .UserProfile import UserProfile
 from .HTTPSession import AboutBlank, FetchForbidden
+from Magic.Magic import Magic
 
 log = logging.getLogger("Thug")
 
@@ -344,22 +344,7 @@ class Navigator(JSClass):
         sha256 = hashlib.sha256()
         sha256.update(response.content)
 
-        try:
-            # This works with python-magic >= 0.4.6 from pypi
-            mtype = magic.from_buffer(response.content, mime = True)
-        except:
-            try:
-                # Ubuntu workaround
-                # This works with python-magic >= 5.22 from Ubuntu (apt)
-                ms = magic.open(magic.MAGIC_MIME)
-                ms.load()
-                mtype = ms.buffer(response.content).split(';')[0]
-            except:
-                # Filemagic workaround
-                # This works with filemagic >= 1.6 from pypi
-                with magic.Magic(flags = magic.MAGIC_MIME_TYPE) as m:
-                    mtype = m.id_buffer(response.content)
-
+        mtype = Magic(response.content).get_mime()
 
         data = {
             "content" : response.content,

--- a/src/Magic/Magic.py
+++ b/src/Magic/Magic.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+#
+# Encoding.py
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA  02111-1307  USA
+
+import magic
+
+class Magic:
+    def __init__(self, data):
+        self.data = data
+
+    def get_mime(self):
+        try:
+            # This works with python-magic >= 0.4.6 from pypi
+            mtype = magic.from_buffer(self.data, mime = True)
+        except:
+            try:
+                # Ubuntu workaround
+                # This works with python-magic >= 5.22 from Ubuntu (apt)
+                ms = magic.open(magic.MAGIC_MIME)
+                ms.load()
+                mtype = ms.buffer(self.data).split(';')[0]
+            except:
+                # Filemagic workaround
+                # This works with filemagic >= 1.6 from pypi
+                with magic.Magic(flags = magic.MAGIC_MIME_TYPE) as m:
+                    mtype = m.id_buffer(self.data)
+
+        return mtype


### PR DESCRIPTION
I implemented `AdodbStream.SaveToFile()`, which now saves the content using the newly modified `ThugLogging.save_file()` API.

I had to reuse the code getting the mime type of a given buffer, so I moved it to a separate module.