### PR TITLE
use mongo connection string in place of host:port

### DIFF
--- a/src/Logging/logging.conf
+++ b/src/Logging/logging.conf
@@ -7,8 +7,7 @@ secret:		edymvouqpfe1ivud
 
 [mongodb]
 enable:     True
-host:		localhost
-port:		27017
+host:		mongodb://localhost:27017
 
 [elasticsearch]
 enable:		True

--- a/src/Logging/logging.conf.default
+++ b/src/Logging/logging.conf.default
@@ -1,16 +1,15 @@
 [hpfeeds]
-enable:		True
+enable:		False
 host:		hpfeeds.honeycloud.net
 port:		10000
 ident:		q6jyo@hp1
 secret:		edymvouqpfe1ivud
 
 [mongodb]
-enable:		False
-host:		localhost
-port:		27017
+enable:     False
+host:		mongodb://localhost:27018
 
 [elasticsearch]
-enable:		True
+enable:		False
 url:		http://192.168.56.101:9200
 index:		thug

--- a/src/Logging/modules/MongoDB.py
+++ b/src/Logging/modules/MongoDB.py
@@ -67,7 +67,7 @@ class MongoDB(object):
 
         if log.ThugOpts.mongodb_address:
             try:
-                (self.opts['host'], self.opts['port']) = log.ThugOpts.mongodb_address.split(':', 1)
+                self.opts['host'] = log.ThugOpts.mongodb_address
                 self.opts['enable'] = 'True'
                 return True
             except:
@@ -110,7 +110,7 @@ class MongoDB(object):
             client = getattr(pymongo, 'Connection', None)
 
         try:
-            connection = client(self.opts['host'], int(self.opts['port']))
+            connection = client(self.opts['host'])
         except:
             log.warning('[MongoDB] MongoDB instance not available')
             self.enabled = False


### PR DESCRIPTION
Use a mongo connection string instead of host and port. 
basic example: mongodb://localhost:27017

This allows for more complex connections including TLS/SSL and authentication. 
Auth example: mongodb://username:password@localhost:27017

https://docs.mongodb.com/v3.0/reference/connection-string/