### PR TITLE
Increase stack size

### DIFF
--- a/src/DOM/DFT.py
+++ b/src/DOM/DFT.py
@@ -91,6 +91,8 @@ class DFT(object):
         self._context          = None
         log.DFT                = self
         self._init_events()
+
+        PyV8.JSEngine.setStackLimit(10 * 1024 * 1024);
    
     def _init_events(self):
         self.listeners = list()


### PR DESCRIPTION
PyV8 allows to configure stack size limit.
A new sample was causing a stack overflow.
Increasing the stack size limit solved the stack overflow issue for this sample.