### PR TITLE
Prevent WScript reset in window

### DIFF
--- a/src/ActiveX/ActiveX.py
+++ b/src/ActiveX/ActiveX.py
@@ -122,7 +122,7 @@ class _ActiveXObject(object):
         for attr_name, attr_value in obj['funcattrs'].items():
             self.funcattrs[attr_name] = methods[attr_value]
 
-        if cls.lower() in ('wscript.shell', ):
+        if cls.lower() in ('wscript.shell', ) and (not hasattr(window, 'WScript') or window.WScript is None):
             window.WScript = self
 
     def __setattr__(self, name, value):


### PR DESCRIPTION
We've been experimenting with overriding/overloading WScript from JavaScript and run into the issue that window.WScript was re-initialized whenever a new WScript.Shell instance was created. This commit fixes that.