### PR TITLE
Fixing missing libemu when running Thug

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -81,6 +81,8 @@ RUN groupadd -r thug && \
   mkdir /home/thug /tmp/thug/logs && \
   chown -R thug:thug /home/thug /tmp/thug/logs
 
+RUN echo "/opt/libemu/lib/" > /etc/ld.so.conf.d/libemu.conf && ldconfig
+
 USER thug
 ENV HOME /home/thug
 ENV USER thug


### PR DESCRIPTION
As suggested by Angelo, the linker seems to have problems finding Libemu.