### PR TITLE
Allow newer pygraphviz versions and fix missing pkg-config

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,7 +48,8 @@ RUN apt-get update && \
     libffi-dev \
     graphviz \
     libfuzzy-dev \
-	libjpeg8-dev \
+    libjpeg8-dev \
+    pkg-config \
     autoconf && \
   rm -rf /var/lib/apt/lists/*
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ PySocks==1.5.6
 cssutils==1.0.1
 zope.interface==4.3.2
 pyparsing==2.1.10
-pygraphviz==1.3.1
+pygraphviz>=1.3.1
 python-magic==0.4.12
 rarfile==2.8
 networkx==1.11


### PR DESCRIPTION
Fixing #187:

- Adding missing `pkg-config` in the apt requirements;
- Allowing newer `pygraphviz` versions (e.g. installing with `easy_install` gets you `1.4rc1`, but then `pip` tries to overwrite it with `1.3.1` and fails because of the missing `pkg-config`).

Cheers,
Pietro