### PR TITLE
GridFS - Remove base64 encoding and add mimetype metadata

### DIFF
--- a/thug/Logging/modules/MongoDB.py
+++ b/thug/Logging/modules/MongoDB.py
@@ -18,7 +18,6 @@
 
 import os
 import datetime
-import base64
 import logging
 from .compatibility import thug_unicode
 
@@ -218,7 +217,9 @@ class MongoDB(object):
             flags = dict()
 
         content    = data.get("content", None)
-        content_id = self.fs.put(base64.b64encode(content)) if content else None
+        content_id = self.fs.put(content,
+            mtype  = data.get("mtype", None)
+        ) if content else None
 
         location = {
             'analysis_id'   : self.analysis_id,


### PR DESCRIPTION
It looks like the sample data gets encoded into base64 before getting thrown into GridFS. A couple of issues I ran into, as a result:

- Unnecessarily increases the size of data getting stored into GridFS.
- GridFS metadata has mismatched md5 from the thug.samples collection md5, because thug.samples is the actual md5 of the sample, while the thugfs.fs.files (metadata) md5 is the base64 encoding of the file.
- Retrieving the file requires decoding. This adds 2 extra steps (encode before put, and decode after get).

I also added an extra metadata key for mimetype (mtype) to make lookups a lot faster. For example, if you wanted to search for a specific mimetype you don't need to search in a different database and collection (thug.samples) to find the ObjectId, before pulling the file. This helps quite a bit when your database is large and you want to pull binaries, to analyze, after a long thug session.