### PR TITLE
Un-string datetime object

### DIFF
--- a/thug/Logging/modules/MongoDB.py
+++ b/thug/Logging/modules/MongoDB.py
@@ -174,7 +174,7 @@ class MongoDB(object):
 
         analysis = {
             "url_id"      : self.url_id,
-            "timestamp"   : str(datetime.datetime.now()),
+            "timestamp"   : datetime.datetime.now(),
             "thug"        : {
                                 "version"            : self.thug_version,
                                 "personality" : {
@@ -429,7 +429,7 @@ class MongoDB(object):
             'description' : self.fix(description),
             'cve'         : self.fix(cve),
             'method'      : self.fix(method),
-            'timestamp'   : str(datetime.datetime.now())
+            'timestamp'   : datetime.datetime.now()
         }
 
         self.behaviors.insert(behavior)


### PR DESCRIPTION
When inserting the "timestamp" field, leaving it as a datetime object allows for simpler querying of date ranges. You can simply use Mongo's query format to return results based on the timestamp:
```
thug.analyses.find({ "timestamp": {"$lt": now, "$gt": last_week } })
```

Using datetime objects also has the added benefit of being consistent across different thug and thugfs documents.

thugfs:
```
> db.fs.files.findOne()
{
        "_id" : ObjectId("583c4c7f2543c30007c2e7a3"),
        "uploadDate" : ISODate("2016-11-28T15:25:51.650Z"),
        "length" : 7832,
        "chunkSize" : 261120,
        "md5" : "30e8d4084c7c03c6948575cf1c5c7845"
}
```
thug.behaviors:
```
> db.behaviors.findOne()
{
        "_id" : ObjectId("583c4c7f2543c30008fc7085"),
        "cve" : "None",
        "analysis_id" : ObjectId("583c4c7f2543c30008fc7084"),
        "timestamp" : "2016-11-28 15:25:51.374512",
        "method" : "Dynamic Analysis"
}
```