### PR TITLE
Modifying config for RTD-docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -91,7 +91,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'classic'
+#html_theme = 'classic'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,0 +1,1 @@
+# This requirements.txt is intentionally left blank for RTD build


### PR DESCRIPTION
With this modification, the build for RTD will pass.
It's weird right now but RTD looks for a `requirements.txt` file and install all the modules from that, earlier it was looking for `requirements.txt` file and install all the modules from it, whereas now a dedicated requirements file(blank) is made available for RTD. 
Also in the `admin` section of RTD, we need to provide the path to this file `docs/source/requirements.txt`. 