### PR TITLE
Modify ElasticSearch export functionality in ElasticSearch.py to be compatible with ES >= 7.0 

### DIFF
--- a/thug/Logging/modules/ElasticSearch.py
+++ b/thug/Logging/modules/ElasticSearch.py
@@ -85,5 +85,5 @@ class ElasticSearch(JSON):
         if not self.enabled:
             return
 
-        res = self.es.index(index = self.opts['index'], doc_type = "analysis", body = self.data)
-        return res['created']
+        res = self.es.index(index = self.opts['index'], body = self.data)
+        return res['_id']


### PR DESCRIPTION
This fix modifies lines 88 and 89 in ElasticSearch.py to adjust the export functionality to be compatible with ES >= 7.0
Tested with ElasticSearch 7.10.0 

Note: The keyword argument `doc_type` is decrecated in ES 7.0 (see https://elasticsearch-py.readthedocs.io/en/7.10.0/api.html#elasticsearch.Elasticsearch.index) Furthermore the result dict returned from  index()-function, does not contain the key 'created' anymore. (See https://www.elastic.co/guide/en/elasticsearch/reference/7.10/docs-index_.html)
