### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ A complement to honeypots, a honeyclient is a tool designed to mimic the behavio
 of a user-driven network client application, such as a web browser, and be
 exploited by an attacker's content.
 
-Thug is a Python low-interaction honeyclient aimed at mimicing the behavior of a
+Thug is a Python low-interaction honeyclient aimed at mimicking the behavior of a
 web browser in order to detect and emulate malicious contents.
 
 

--- a/thug/DOM/W3C/HTML/HTMLDocumentCompatibleInfo.py
+++ b/thug/DOM/W3C/HTML/HTMLDocumentCompatibleInfo.py
@@ -4,7 +4,7 @@
 class HTMLDocumentCompatibleInfo:
     """
     IHTMLDocumentCompatibleInfo provides information about the
-    compatibity mode specified by the web page. If the web page
+    compatibility mode specified by the web page. If the web page
     specifies multiple compatibility modes, they can be retrieved
     using IHTMLDocumentCompatibleInfoCollection.
 

--- a/thug/Logging/ThugLogging.py
+++ b/thug/Logging/ThugLogging.py
@@ -250,7 +250,7 @@ class ThugLogging(BaseLogging, SampleLogging):
         """
         Log file information for a given url
 
-        @url            URL where this exploit occured
+        @url            URL where this exploit occurred
         @module         Module/ActiveX Control, ... that gets exploited
         @description    Description of the exploit
         @cve            CVE number (if available)

--- a/thug/Logging/modules/JSON.py
+++ b/thug/Logging/modules/JSON.py
@@ -234,7 +234,7 @@ class JSON:
         """
         Log file information for a given url
 
-        @url            URL where this exploit occured
+        @url            URL where this exploit occurred
         @module         Module/ActiveX Control, ... that gets exploited
         @description    Description of the exploit
         @cve            CVE number (if available)

--- a/thug/Logging/modules/MongoDB.py
+++ b/thug/Logging/modules/MongoDB.py
@@ -229,7 +229,7 @@ class MongoDB:
         """
         Log file information for a given url
 
-        @url            URL where this exploit occured
+        @url            URL where this exploit occurred
         @module         Module/ActiveX Control, ... that gets exploited
         @description    Description of the exploit
         @cve            CVE number (if available)

--- a/thug/ThugAPI/IThugAPI.py
+++ b/thug/ThugAPI/IThugAPI.py
@@ -846,7 +846,7 @@ class IThugAPI(zope.interface.Interface):
 
         and defines the custom classifier scope.
 
-        The parameter `method' is the method (not its name) to be additionaly invoked.
+        The parameter `method' is the method (not its name) to be additionally invoked.
         The method parameters depend on the `cls_type' value and are listed here for
         convenience
 


### PR DESCRIPTION
There are small typos in:
- README.rst
- thug/DOM/W3C/HTML/HTMLDocumentCompatibleInfo.py
- thug/Logging/ThugLogging.py
- thug/Logging/modules/JSON.py
- thug/Logging/modules/MongoDB.py
- thug/ThugAPI/IThugAPI.py

Fixes:
- Should read `occurred` rather than `occured`.
- Should read `mimicking` rather than `mimicing`.
- Should read `compatibility` rather than `compatibity`.
- Should read `additionally` rather than `additionaly`.

Closes #319