### PR TITLE
include package data for pip installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Topic :: Security",
     ],
+    include_package_data=True,
     package_data = {
            ""       : ["*.js"],
            },


### PR DESCRIPTION
### changes

adds `include_package_data=True` to thug's `setup.py` so that when it's installed with `pip`, the package data (config files etc) is correctly added.

### testing

brought up a container, cloned master, ran `pip install .`, verified that thug installed but the config files were not present

switched to this branch, brought up new container, ran `pip install .`, verified that thug config files were added in `/etc/thug`