### PR TITLE
Fix sensitive data exposure: Change access to `thug-profiler.log` file

### DIFF
--- a/thug/thug.py
+++ b/thug/thug.py
@@ -379,7 +379,11 @@ def main():
         s  = io.StringIO()
         ps = pstats.Stats(profiler, stream = s).sort_stats('cumulative')
         ps.print_stats()
-        with open('/tmp/thug-profiler.log', encoding = 'utf-8', mode = 'w') as fd: # nosec
+
+        def opener(path):
+            return os.open(path, 0o644)
+
+        with open('/tmp/thug-profiler.log', encoding = 'utf-8', mode = 'w', opener = opener) as fd:
             fd.write(s.getvalue())
 
 


### PR DESCRIPTION
## Details
While triaging your project, our bug fixing tool generated the following message(s)-

> In file: [thug.py](https://github.com/buffer/thug/blob/master/thug/thug.py#L382), there is a method: main that creates a temporary file using a hard coded path to a public writable directory. This exposes the temporarily created file to race condition attacks. An attacker can access, modify or even delete a file. iCR suggested that a temporary file should be created using a safe API in a secured directory instead.

### Notes
For example, let's take the following script as an example - 
```py
import os

def opener(path, flags):
    return os.open(path, flags, 0o640)

with open('/tmp/thug-profiler-good.log', encoding = 'utf-8', mode = 'w', opener = opener) as fd:
    fd.write("*** Some things ***")

with open('/tmp/thug-profiler-bad.log', encoding = 'utf-8', mode = 'w') as fd:
    fd.write("*** Some things ***")
```

After executing the script, we'd find two files called `thug-profiler-good.log` and `thug-profiler-bad.log` in the `/tmp` directory as below -

```sh
$ ls -la /tmp/thug-profiler-*
-rw-rw-r-- 1 ataf ataf 30 Oct 16 16:52 /tmp/thug-profiler-bad.log
-rw-r----- 1 ataf ataf 28 Oct 16 16:52 /tmp/thug-profiler-good.log
```
Here, we can see that the `thug-profiler-bad.log` file was created with permission `664` whereas the new `thug-profiler-good.log` file is created with permission `640`. 

Since `/tmp` is a public folder that's accessible from everyone, it's recommended that special measures should be taken so that files written to this directory can't be overridden or removed by others.


## Changes
Implemented an `opener()` method that opens the file with permission `644 (rw-r--r--)`


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
