### PR TITLE
GitHub actions: Add dependabot.yml to manage requirements updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "Update requirements"


### PR DESCRIPTION
You should probably enable _Dependabot_ from _Settings_ panel of your repository:

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#enabling-dependabot-version-updates