### PR TITLE
Porting thug cli from getopt to argparse

### DIFF
--- a/thug/thug.py
+++ b/thug/thug.py
@@ -16,11 +16,10 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 # MA  02111-1307  USA
 
+import argparse
+import logging
 import os
 import sys
-import getopt
-import logging
-
 from .ThugAPI import ThugAPI
 from .Plugins.ThugPlugins import ThugPlugins
 from .Plugins.ThugPlugins import PRE_ANALYSIS_PLUGINS
@@ -31,101 +30,12 @@ log.setLevel(logging.WARN)
 
 
 class Thug(ThugAPI):
-    def __init__(self, args):
+    def __init__(self, args: argparse.Namespace):
         self.args = args
         ThugAPI.__init__(self)
 
-    def usage(self):
-        msg = """
-Synopsis:
-    Thug: Pure Python honeyclient implementation
-
-    Usage:
-        thug [ options ] url
-
-    Options:
-        -h, --help                  \tDisplay this help information
-        -V, --version               \tDisplay Thug version
-        -i, --list-ua               \tDisplay available user agents
-        -u, --useragent=            \tSelect a user agent (use option -b for values, default: winxpie60)
-        -e, --events=               \tEnable comma-separated specified DOM events handling
-        -w, --delay=                \tSet a maximum setTimeout/setInterval delay value (in milliseconds)
-        -n, --logdir=               \tSet the log output directory
-        -o, --output=               \tLog to a specified file
-        -r, --referer               \tSpecify a referer
-        -p, --proxy=                \tSpecify a proxy (see below for format and supported schemes)
-        -m, --attachment            \tSet the attachment mode
-        -l, --local                 \tAnalyze a locally saved page
-        -x, --local-nofetch         \tAnalyze a locally saved page and prevent remote content fetching
-        -v, --verbose               \tEnable verbose mode
-        -d, --debug                 \tEnable debug mode
-        -q, --quiet                 \tDisable console logging
-        -g, --http-debug            \tEnable HTTP debug mode
-        -t, --threshold             \tMaximum pages to fetch
-        -j, --extensive             \tExtensive fetch of linked pages
-        -O, --connect-timeout       \tSet the connect timeout (in seconds, default: 10 seconds)
-        -Y, --proxy-connect-timeout \tSet the proxy connect timeout (in seconds, default: 5 seconds)
-        -T, --timeout=              \tSet the analysis timeout (in seconds, default: 600 seconds)
-        -c, --broken-url            \tSet the broken URL mode
-        -z, --web-tracking          \tEnable web client tracking inspection
-        -b, --async-prefetch        \tEnable async prefetching mode
-        -k, --no-honeyagent         \tDisable HoneyAgent support
-        -a, --image-processing      \tEnable image processing analysis
-        -f, --screenshot            \tEnable screenshot capturing
-        -E, --awis                  \tEnable AWS Alexa Web Information Service (AWIS)
-        -s, --no-down-prevent       \tDisable download prevention mechanism
-
-        Plugins:
-        -A, --adobepdf=             \tSpecify Adobe Acrobat Reader version (default: 9.1.0)
-        -P, --no-adobepdf           \tDisable Adobe Acrobat Reader plugin
-        -S, --shockwave=            \tSpecify Shockwave Flash version (default: 10.0.64.0)
-        -R, --no-shockwave          \tDisable Shockwave Flash plugin
-        -J, --javaplugin=           \tSpecify JavaPlugin version (default: 1.6.0.32)
-        -K, --no-javaplugin         \tDisable Java plugin
-        -L, --silverlight           \tSpecify SilverLight version (default: 4.0.50826.0)
-        -N, --no-silverlight        \tDisable SilverLight plugin
-
-        Classifiers:
-        --htmlclassifier=           \tSpecify a list of additional (comma separated) HTML classifier rule files
-        --urlclassifier=            \tSpecify a list of additional (comma separated) URL classifier rule files
-        --jsclassifier=             \tSpecify a list of additional (comma separated) JS classifier rule files
-        --vbsclassifier=            \tSpecify a list of additional (comma separated) VBS classifier rule files
-        --sampleclassifier=         \tSpecify a list of additional (comma separated) Sample classifier rule files
-        --textclassifier=           \tSpecify a list of additional (comma separated) Text classifier rule files
-        --cookieclassifier=         \tSpecify a list of additional (comma separated) Cookie classifier rule files
-        --imageclassifier=          \tSpecify a list of additional (comma separated) Image classifier rule files
-        --htmlfilter=               \tSpecify a list of additional (comma separated) HTML filter files
-        --urlfilter=                \tSpecify a list of additional (comma separated) URL filter files
-        --jsfilter=                 \tSpecify a list of additional (comma separated) JS filter files
-        --vbsfilter=                \tSpecify a list of additional (comma separated) VBS filter files
-        --samplefilter=             \tSpecify a list of additional (comma separated) Sample filter files
-        --textfilter=               \tSpecify a list of additional (comma separated) Text filter files
-        --cookiefilter=             \tSpecify a list of additional (comma separated) Cookie filter files
-        --imagefilter=              \tSpecify a list of additional (comma separated) Image filter files
-
-        Logging:
-        -F, --file-logging          \tEnable file logging mode (default: disabled)
-        -Z, --json-logging          \tEnable JSON logging mode (default: disabled)
-        -W, --features-logging      \tEnable features logging mode (default: disabled)
-        -G, --elasticsearch-logging \tEnable ElasticSearch logging mode (default: disabled)
-        -D, --mongodb-address=      \tSpecify address and port of the MongoDB instance (format: host:port)
-        -Y, --no-code-logging       \tDisable code logging
-        -U, --no-cert-logging       \tDisable SSL/TLS certificate logging
-
-    Proxy Format:
-        scheme://[username:password@]host:port (supported schemes: http, socks4, socks5, socks5h)
-"""
-
-        print(msg)
-        sys.exit(0)
-
     def list_ua(self):
-        msg = """
-Synopsis:
-    Thug: Pure Python honeyclient implementation
-
-    Available User-Agents:
-"""
+        msg = """\n    Available User-Agents:\n\n"""
 
         for key, value in sorted(
             iter(log.ThugOpts.Personality.items()),
@@ -137,365 +47,425 @@ Synopsis:
         sys.exit(0)
 
     def analyze(self):
-        p = getattr(self, "run_remote", None)
-
-        try:
-            options, args = getopt.getopt(
-                self.args,
-                "hViu:e:w:n:o:r:p:mzbkafEslxvdqgA:PS:RJ:KL:Nt:jO:Y:T:cFZWGYUD:",
-                [
-                    "help",
-                    "version",
-                    "list-ua",
-                    "useragent=",
-                    "events=",
-                    "delay=",
-                    "logdir=",
-                    "output=",
-                    "referer=",
-                    "proxy=",
-                    "attachment",
-                    "web-tracking",
-                    "async-prefetch",
-                    "no-honeyagent",
-                    "image-processing",
-                    "screenshot",
-                    "awis",
-                    "no-down-prevent",
-                    "local",
-                    "local-nofetch",
-                    "verbose",
-                    "debug",
-                    "quiet",
-                    "http-debug",
-                    "adobepdf=",
-                    "no-adobepdf",
-                    "shockwave=",
-                    "no-shockwave",
-                    "javaplugin=",
-                    "no-javaplugin",
-                    "silverlight=",
-                    "no-silverlight",
-                    "threshold=",
-                    "extensive",
-                    "connect-timeout=",
-                    "proxy-connect-timeout=",
-                    "timeout=",
-                    "broken-url",
-                    "htmlclassifier=",
-                    "urlclassifier=",
-                    "jsclassifier=",
-                    "vbsclassifier=",
-                    "sampleclassifier=",
-                    "imageclassifier=",
-                    "textclassifier=",
-                    "cookieclassifier=",
-                    "htmlfilter=",
-                    "urlfilter=",
-                    "jsfilter=",
-                    "vbsfilter=",
-                    "samplefilter=",
-                    "textfilter=",
-                    "cookiefilter=",
-                    "imagefilter=",
-                    "file-logging",
-                    "json-logging",
-                    "features-logging",
-                    "elasticsearch-logging",
-                    "no-code-logging",
-                    "no-cert-logging",
-                    "mongodb-address=",
-                ],
-            )
-        except getopt.GetoptError:
-            self.usage()
-
-        if not options and not args:
-            self.usage()
-
-        for option in options:
-            if option[0] in ("-h", "--help"):
-                self.usage()
-            elif option[0] in ("-V", "--version"):
-                self.version()
-            elif option[0] in ("-i", "--list-ua"):
-                self.list_ua()
-
+        p = (
+            getattr(self, "run_local")
+            if self.args.local or self.args.local_nofetch
+            else getattr(self, "run_remote")
+        )
         self.set_raise_for_proxy(False)
 
-        for option in options:
-            if option[0] in (
-                "-u",
-                "--useragent",
-            ):
-                self.set_useragent(option[1])
-            elif option[0] in ("-e", "--events"):
-                self.set_events(option[1])
-            elif option[0] in ("-w", "--delay"):
-                self.set_delay(option[1])
-            elif option[0] in (
-                "-r",
-                "--referer",
-            ):
-                self.set_referer(option[1])
-            elif option[0] in (
-                "-p",
-                "--proxy",
-            ):
-                self.set_proxy(option[1])
-            elif option[0] in (
-                "-m",
-                "--attachment",
-            ):
-                self.set_attachment()
-            elif option[0] in (
-                "-z",
-                "--web-tracking",
-            ):
-                self.set_web_tracking()
-            elif option[0] in (
-                "-b",
-                "--async-prefetch",
-            ):
-                self.set_async_prefetch()
-            elif option[0] in (
-                "-k",
-                "--no-honeyagent",
-            ):
-                self.disable_honeyagent()
-            elif option[0] in (
-                "-a",
-                "--image-processing",
-            ):
-                self.set_image_processing()
-            elif option[0] in (
-                "-f",
-                "--screenshot",
-            ):
-                self.enable_screenshot()
-            elif option[0] in (
-                "-E",
-                "--awis",
-            ):
-                self.enable_awis()
-            elif option[0] in (
-                "-s",
-                "--no-down-prevent",
-            ):
-                self.disable_download_prevent()
-            elif option[0] in (
-                "-l",
-                "--local",
-            ):
-                p = getattr(self, "run_local")
-            elif option[0] in (
-                "-x",
-                "--local-nofetch",
-            ):
-                p = getattr(self, "run_local")
-                self.set_no_fetch()
-            elif option[0] in (
-                "-v",
-                "--verbose",
-            ):
-                self.set_verbose()
-            elif option[0] in (
-                "-d",
-                "--debug",
-            ):
-                self.set_debug()
-            elif option[0] in (
-                "-a",
-                "--ast-debug",
-            ):
-                self.set_ast_debug()
-            elif option[0] in (
-                "-g",
-                "--http-debug",
-            ):
-                self.set_http_debug()
-            elif option[0] in (
-                "-A",
-                "--adobepdf",
-            ):
-                self.set_acropdf_pdf(option[1])
-            elif option[0] in (
-                "-P",
-                "--no-adobepdf",
-            ):
-                self.disable_acropdf()
-            elif option[0] in (
-                "-S",
-                "--shockwave",
-            ):
-                self.set_shockwave_flash(option[1])
-            elif option[0] in (
-                "-R",
-                "--no-shockwave",
-            ):
-                self.disable_shockwave_flash()
-            elif option[0] in (
-                "-J",
-                "--javaplugin",
-            ):
-                self.set_javaplugin(option[1])
-            elif option[0] in (
-                "-K",
-                "--no-javaplugin",
-            ):
-                self.disable_javaplugin()
-            elif option[0] in (
-                "-L",
-                "--silverlight",
-            ):
-                self.set_silverlight(option[1])
-            elif option[0] in (
-                "-N",
-                "--no-silverlight",
-            ):
-                self.disable_silverlight()
-            elif option[0] in (
-                "-t",
-                "--threshold",
-            ):
-                self.set_threshold(option[1])
-            elif option[0] in (
-                "-j",
-                "--extensive",
-            ):
-                self.set_extensive()
-            elif option[0] in (
-                "-O",
-                "--connect-timeout",
-            ):
-                self.set_connect_timeout(option[1])
-            elif option[0] in (
-                "-Y",
-                "--proxy-connect-timeout",
-            ):
-                self.set_proxy_connect_timeout(option[1])
-            elif option[0] in (
-                "-T",
-                "--timeout",
-            ):
-                self.set_timeout(option[1])
-            elif option[0] in ("--htmlclassifier",):
-                for classifier in option[1].split(","):
-                    self.add_htmlclassifier(os.path.abspath(classifier))
-            elif option[0] in ("--urlclassifier",):
-                for classifier in option[1].split(","):
-                    self.add_urlclassifier(os.path.abspath(classifier))
-            elif option[0] in ("--jsclassifier",):
-                for classifier in option[1].split(","):
-                    self.add_jsclassifier(os.path.abspath(classifier))
-            elif option[0] in ("--vbsclassifier",):
-                for classifier in option[1].split(","):
-                    self.add_vbsclassifier(os.path.abspath(classifier))
-            elif option[0] in ("--sampleclassifier",):
-                for classifier in option[1].split(","):
-                    self.add_sampleclassifier(os.path.abspath(classifier))
-            elif option[0] in ("--textclassifier",):
-                for classifier in option[1].split(","):
-                    self.add_textclassifier(os.path.abspath(classifier))
-            elif option[0] in ("--cookieclassifier",):
-                for classifier in option[1].split(","):
-                    self.add_cookieclassifier(os.path.abspath(classifier))
-            elif option[0] in ("--imageclassifier",):
-                for classifier in option[1].split(","):
-                    self.add_imageclassifier(os.path.abspath(classifier))
-            elif option[0] in ("--htmlfilter",):
-                for f in option[1].split(","):
-                    self.add_htmlfilter(os.path.abspath(f))
-            elif option[0] in ("--urlfilter",):
-                for f in option[1].split(","):
-                    self.add_urlfilter(os.path.abspath(f))
-            elif option[0] in ("--jsfilter",):
-                for f in option[1].split(","):
-                    self.add_jsfilter(os.path.abspath(f))
-            elif option[0] in ("--vbsfilter",):
-                for f in option[1].split(","):
-                    self.add_vbsfilter(os.path.abspath(f))
-            elif option[0] in ("--samplefilter",):
-                for f in option[1].split(","):
-                    self.add_samplefilter(os.path.abspath(f))
-            elif option[0] in ("--textfilter",):
-                for f in option[1].split(","):
-                    self.add_textfilter(os.path.abspath(f))
-            elif option[0] in ("--cookiefilter",):
-                for f in option[1].split(","):
-                    self.add_cookiefilter(os.path.abspath(f))
-            elif option[0] in ("--imagefilter",):
-                for f in option[1].split(","):
-                    self.add_imagefilter(os.path.abspath(f))
-            elif option[0] in (
-                "-c",
-                "--broken-url",
-            ):
-                self.set_broken_url()
-            elif option[0] in (
-                "-F",
-                "--file-logging",
-            ):
-                self.set_file_logging()
-            elif option[0] in (
-                "-Z",
-                "--json-logging",
-            ):
-                self.set_json_logging()
-            elif option[0] in (
-                "-W",
-                "--features-logging",
-            ):
-                self.set_features_logging()
-            elif option[0] in (
-                "-G",
-                "--elasticsearch-logging",
-            ):
-                self.set_elasticsearch_logging()
-            elif option[0] in (
-                "-Y",
-                "--no-code-logging",
-            ):
-                self.disable_code_logging()
-            elif option[0] in (
-                "-U",
-                "--no-cert-logging",
-            ):
-                self.disable_cert_logging()
-            elif option[0] in (
-                "-D",
-                "--mongodb-address",
-            ):
-                self.set_mongodb_address(option[1])
+        for arg_name, arg_value in vars(self.args).items():
+            if arg_name in ("url", "local", "local_nofetch"):
+                continue
+            if m := getattr(self, arg_name):
+                if (
+                    arg_name.startswith("add_")
+                    and isinstance(arg_value, list)
+                    and arg_value
+                ):
+                    for item in arg_value:
+                        m(item)
+                elif isinstance(arg_value, str) and arg_value:
+                    m(arg_value)
+                elif isinstance(arg_value, bool) and arg_value:
+                    m()
+            else:
+                raise RuntimeError(
+                    f"Unable to handle the argument {arg_name} with value {arg_value}"
+                )
 
-        self.log_init(args[0])
-
-        for option in options:
-            if option[0] in ("-n", "--logdir"):
-                self.set_log_dir(option[1])
-            elif option[0] in (
-                "-o",
-                "--output",
-            ):
-                self.set_log_output(option[1])
-            elif option[0] in (
-                "-q",
-                "--quiet",
-            ):
-                self.set_log_quiet()
+        self.log_init(self.args.url)
 
         if p:  # pylint:disable=using-constant-test
             ThugPlugins(PRE_ANALYSIS_PLUGINS, self)()
-            p(args[0])
+            p(self.args.url)
             ThugPlugins(POST_ANALYSIS_PLUGINS, self)()
 
         self.log_event()
         return log
 
 
+def parse_args() -> argparse.Namespace:
+    def rules_list(rules_arg: str) -> list[str]:
+        return list(map(os.path.abspath, rules_arg.split(",")))
+
+    parser = argparse.ArgumentParser(
+        prog="thug",
+        description="Thug: Pure Python honeyclient implementation",
+        formatter_class=argparse.RawTextHelpFormatter,
+        epilog="""Proxy Format:\n\tscheme://[username:password@]host:port (supported schemes: http, socks4, socks5, socks5h)""",
+    )
+    parser.add_argument("url", help="URL to be analyzed", nargs="?")
+    parser.add_argument(
+        "-V", "--version", help="Display Thug version", action="store_true"
+    )
+    parser.add_argument(
+        "-i", "--list-ua", help="Display available user agents", action="store_true"
+    )
+    parser.add_argument(
+        "-u",
+        "--useragent",
+        help="Select a user agent (use option -b for values, default: winxpie60)",
+        dest="set_useragent",
+    )
+    parser.add_argument(
+        "-e",
+        "--events",
+        help="Enable comma-separated specified DOM events handling",
+        dest="set_events",
+    )
+    parser.add_argument(
+        "-w",
+        "--delay",
+        help="Set a maximum setTimeout/setInterval delay value (in milliseconds)",
+        dest="set_delay",
+    )
+    parser.add_argument(
+        "-n", "--logdir", help="Set the log output directory", dest="set_log_dir"
+    )
+    parser.add_argument(
+        "-o", "--output", help="Log to a specified file", dest="set_log_output"
+    )
+    parser.add_argument("-r", "--referer", help="Specify a referer", dest="set_referer")
+    parser.add_argument(
+        "-p",
+        "--proxy",
+        help="Specify a proxy (see below for format and supported schemes)",
+        dest="set_proxy",
+    )
+    parser.add_argument(
+        "-m",
+        "--attachment",
+        help="Set the attachment mode",
+        dest="set_attachment",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-z",
+        "--web-tracking",
+        help="Enable web client tracking inspection",
+        dest="set_web_tracking",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-b",
+        "--async-prefetch",
+        help="Enable async prefetching mode",
+        dest="set_async_prefetch",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-k",
+        "--no-honeyagent",
+        help="Disable HoneyAgent support",
+        dest="disable_honeyagent",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-a",
+        "--image-processing",
+        help="Enable image processing analysis",
+        dest="set_image_processing",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-f",
+        "--screenshot",
+        help="Enable screenshot capturing",
+        dest="enable_screenshot",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-E",
+        "--awis",
+        help="Enable AWS Alexa Web Information Service (AWIS)",
+        dest="enable_awis",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-s",
+        "--no-down-prevent",
+        help="Disable download prevention mechanism",
+        dest="disable_download_prevent",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-l", "--local", help="Analyze a locally saved page", action="store_true"
+    )
+    parser.add_argument(
+        "-x",
+        "--local-nofetch",
+        help="Analyze a locally saved page and prevent remote content fetching",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        help="Enable verbose mode",
+        dest="set_verbose",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-d", "--debug", help="Enable debug mode", dest="set_debug", action="store_true"
+    )
+    # parser.add_argument("-a", "--ast-debug", help="Enable ast debug mode", dest='st_ast_debug, action='store_true')
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        help="Disable console logging",
+        dest="set_log_quiet",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-g",
+        "--http-debug",
+        help="Enable HTTP debug mode",
+        dest="set_http_debug",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-A",
+        "--adobepdf",
+        help="Specify Adobe Acrobat Reader version (default: 9.1.0",
+        dest="set_acropdf_pdf",
+    )
+    parser.add_argument(
+        "-P",
+        "--no-adobepdf",
+        help="Disable Adobe Acrobat Reader plugin",
+        dest="disable_acropdf",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-S",
+        "--shockwave",
+        help="Specify Shockwave Flash version (default: 10.0.64.0)",
+        dest="set_shockwave_flash",
+    )
+    parser.add_argument(
+        "-R",
+        "--no-shockwave",
+        help="Disable Shockwave Flash plugin",
+        dest="disable_shockwave_flash",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-J",
+        "--javaplugin",
+        help="Specify JavaPlugin version (default: 1.6.0.32)",
+        dest="set_javaplugin",
+    )
+    parser.add_argument(
+        "-K",
+        "--no-javaplugin",
+        help="Disable Java plugin",
+        dest="disable_javaplugin",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-L",
+        "--silverlight",
+        help="Specify SilverLight version (default: 4.0.50826.0)",
+        dest="set_silverlight",
+    )
+    parser.add_argument(
+        "-N",
+        "--no-silverlight",
+        help="Disable SilverLight plugin",
+        dest="disable_silverlight",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-t", "--threshold", help="Maximum pages to fetch", dest="set_threshold"
+    )
+    parser.add_argument(
+        "-j",
+        "--extensive",
+        help="Extensive fetch of linked pages",
+        dest="set_extensive",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-O",
+        "--connect-timeout",
+        help="Set the connect timeout (in seconds, default: 10 seconds)",
+        dest="set_connect_timeout",
+    )
+    parser.add_argument(
+        "-B",
+        "--proxy-connect-timeout",
+        help="Set the proxy connect timeout (in seconds, default: 5 seconds)",
+        dest="set_proxy_connect_timeout",
+    )
+    parser.add_argument(
+        "-T",
+        "--timeout",
+        help="Set the analysis timeout (in seconds, default: 600 seconds)",
+        dest="set_timeout",
+    )
+    parser.add_argument(
+        "-c",
+        "--broken-url",
+        help="Set the broken URL mode",
+        dest="set_broken_url",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--htmlclassifier",
+        help="Specify a list of additional (comma separated) HTML classifier rule files",
+        type=rules_list,
+        dest="add_htmlclassifier",
+    )
+    parser.add_argument(
+        "--urlclassifier",
+        help="Specify a list of additional (comma separated) URL classifier rule files",
+        type=rules_list,
+        dest="add_urlclassifier",
+    )
+    parser.add_argument(
+        "--jsclassifier",
+        help="Specify a list of additional (comma separated) JS classifier rule files",
+        type=rules_list,
+        dest="add_jsclassifier",
+    )
+    parser.add_argument(
+        "--vbsclassifier",
+        help="Specify a list of additional (comma separated) VBS classifier rule files",
+        type=rules_list,
+        dest="add_vbsclassifier",
+    )
+    parser.add_argument(
+        "--sampleclassifier",
+        help="Specify a list of additional (comma separated) Sample classifier rule files",
+        type=rules_list,
+        dest="add_sampleclassifier",
+    )
+    parser.add_argument(
+        "--textclassifier",
+        help="Specify a list of additional (comma separated) Text classifier rule files",
+        type=rules_list,
+        dest="add_textclassifier",
+    )
+    parser.add_argument(
+        "--cookieclassifier",
+        help="Specify a list of additional (comma separated) Cookie classifier rule files",
+        type=rules_list,
+        dest="add_cookieclassifier",
+    )
+    parser.add_argument(
+        "--imageclassifier",
+        help="Specify a list of additional (comma separated) Image classifier rule files",
+        type=rules_list,
+        dest="add_imageclassifier",
+    )
+    parser.add_argument(
+        "--htmlfilter",
+        help="Specify a list of additional (comma separated) HTML filter files",
+        type=rules_list,
+        dest="add_htmlfilter",
+    )
+    parser.add_argument(
+        "--urlfilter",
+        help="Specify a list of additional (comma separated) URL filter files",
+        type=rules_list,
+        dest="add_urlfilter",
+    )
+    parser.add_argument(
+        "--jsfilter",
+        help="Specify a list of additional (comma separated) JS filter files",
+        type=rules_list,
+        dest="add_jsfilter",
+    )
+    parser.add_argument(
+        "--vbsfilter",
+        help="Specify a list of additional (comma separated) VBS filter files",
+        type=rules_list,
+        dest="add_vbsfilter",
+    )
+    parser.add_argument(
+        "--samplefilter",
+        help="Specify a list of additional (comma separated) Sample filter files",
+        type=rules_list,
+        dest="add_samplefilter",
+    )
+    parser.add_argument(
+        "--textfilter",
+        help="Specify a list of additional (comma separated) Text filter files",
+        type=rules_list,
+        dest="add_textfilter",
+    )
+    parser.add_argument(
+        "--cookiefilter",
+        help="Specify a list of additional (comma separated) Cookie filter files",
+        type=rules_list,
+        dest="add_cookiefilter",
+    )
+    parser.add_argument(
+        "--imagefilter",
+        help="Specify a list of additional (comma separated) Image filter files",
+        type=rules_list,
+        dest="add_imagefilter",
+    )
+    parser.add_argument(
+        "-F",
+        "--file-logging",
+        help="Enable file logging mode (default: disabled)",
+        dest="set_file_logging",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-Z",
+        "--json-logging",
+        help="Enable JSON logging mode (default: disabled)",
+        dest="set_json_logging",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-W",
+        "--features-logging",
+        help="Enable features logging mode (default: disabled)",
+        dest="set_features_logging",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-G",
+        "--elasticsearch-logging",
+        help="Enable ElasticSearch logging mode (default: disabled)",
+        dest="set_elasticsearch_logging",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-D",
+        "--mongodb-address",
+        help="Specify address and port of the MongoDB instance (format: host:port)",
+        dest="set_mongodb_address",
+    )
+    parser.add_argument(
+        "-Y",
+        "--no-code-logging",
+        help="Disable code logging",
+        dest="disable_code_logging",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-U",
+        "--no-cert-logging",
+        help="Disable SSL/TLS certificate logging",
+        dest="disable_cert_logging",
+        action="store_true",
+    )
+    args = parser.parse_args()
+    if not any([args.url, args.local, args.local_nofetch, args.version, args.list_ua]):
+        parser.print_help()
+        parser.exit(1, "Missing required argument(s)!")
+    return args
+
+
 def main():
+    args = parse_args()
+
     if not os.getenv("THUG_PROFILE", None):
-        Thug(sys.argv[1:])()
+        Thug(args)()
     else:
         import io
         import cProfile
@@ -504,7 +474,7 @@ def main():
 
         profiler = cProfile.Profile()
         profiler.enable()
-        Thug(sys.argv[1:])()
+        Thug(args)()
         profiler.disable()
 
         s = io.StringIO()


### PR DESCRIPTION
- Refactored the `thug.py` main file to port cli from `getopt` to `argparse`
- Replaced the `-Y` arg flag with `-B` for the `proxy-connect-timeout` option since it was clashing with `no-code-logging` one